### PR TITLE
fix .travis.yml for old version of php

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.4
   - 5.5


### PR DESCRIPTION
see https://travis-ci.community/t/php-5-4-and-5-5-archives-missing/3723/4